### PR TITLE
Update dagster-cloud to 1.13.15

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 context:
   python_min: '3.10'
   name: dagster-cloud
-  version: "1.13.2"
+  version: "1.13.15"
 
 package:
   name: ${{ name|lower }}
@@ -11,7 +11,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/${{ name | replace('-', '_') }}-${{ version }}.tar.gz
-  sha256: 40294742c5d764b02c5d92d537ede29c1c596c2815cafafb65d14764fae2a381
+  sha256: 7a703411f84a716792bef03922fa5daf8aaa380abd9f16d6b5da77b79d77863b
 
 build:
   number: 0


### PR DESCRIPTION
Updates dagster-cloud to 1.13.15.\n\nValidation:\n- Confirmed conda-forge has dagster, dagster-cloud-cli, and dagster-shared 1.13.15 packages published.\n- rattler-build build -r recipe -c conda-forge --log-style plain passed locally on osx-arm64, including import test and pip check.\n\nContext: PR #97 failed because dagster 1.13.6 was not available when its test environment solved; that dependency chain is now present for 1.13.15.